### PR TITLE
Bugfix/relation joined events

### DIFF
--- a/tests/integration/test_charm_clustered.py
+++ b/tests/integration/test_charm_clustered.py
@@ -22,7 +22,7 @@ from pytest_operator.plugin import OpsTest
 logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
-DEPLOY_TIMEOUT = 45 * 60  # 45min
+DEPLOY_TIMEOUT = 60 * 60  # 1h
 OPERATION_TIMEOUT = 60 * 5  # 5min
 APP_NAME = METADATA["name"]
 BUNDLE_FILENAME = Path("tests/integration/bundles/incus_clustered.yaml.j2").absolute()

--- a/tests/unit/test_certificates_relation.py
+++ b/tests/unit/test_certificates_relation.py
@@ -19,8 +19,8 @@ from charm import IncusCharm
 @pytest.mark.parametrize(
     "leader,is_clustered", [(False, False), (True, False), (False, True), (True, True)]
 )
-def test_certificates_relation_created(leader, is_clustered):
-    """Test the certificates-relation-created event.
+def test_certificates_relation_joined(leader, is_clustered):
+    """Test the certificates-relation-joined event.
 
     The unit should populate the relation data with the information needed
     to generate a new certificate.
@@ -49,7 +49,7 @@ def test_certificates_relation_created(leader, is_clustered):
             ],
         )
 
-        out = ctx.run(ctx.on.relation_created(relation=relation), state)
+        out = ctx.run(ctx.on.relation_joined(relation=relation), state)
 
         relation = out.get_relation(relation.id)
         assert relation.local_unit_data["unit_name"] == "incus_0"


### PR DESCRIPTION
We've observed that in some environments Juju does not emit the
relation-created event reliably. This caused the leader unit to never
setup the application data correctly, leading to a deadlock when forming
the cluster. By moving the setting of application data to the
relation-joined event, we hope to be more resilient to missing events.


Signed-off-by: Luís Simas <luissimas@protonmail.com>