### PR TITLE
feat: add oidc config options

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -119,6 +119,62 @@ config:
         Whether to enable the Incus Web UI.
       default: false
       type: boolean
+    oidc-audience:
+      description: |
+        The expected audience value for the application.
+
+        For more information, refer to the Incus documentation:
+        https://linuxcontainers.org/incus/docs/main/server_config/#openid-connect-configuration
+      type: string
+    oidc-claim:
+      description: |
+        OpenID Connect claim to use as the username.
+
+        For more information, refer to the Incus documentation:
+        https://linuxcontainers.org/incus/docs/main/server_config/#openid-connect-configuration
+      type: string
+    oidc-client-id:
+      description: |
+        OpenID Connect client ID for the application.
+
+        For more information, refer to the Incus documentation:
+        https://linuxcontainers.org/incus/docs/main/server_config/#openid-connect-configuration
+      type: string
+    oidc-issuer:
+      description: |
+        OpenID Connect Discovery URL for the provider.
+
+        For more information, refer to the Incus documentation:
+        https://linuxcontainers.org/incus/docs/main/server_config/#openid-connect-configuration
+      type: string
+    oidc-scopes:
+      description: |
+        Comma separated list of OpenID Connect scopes.
+
+        For more information, refer to the Incus documentation:
+        https://linuxcontainers.org/incus/docs/main/server_config/#openid-connect-configuration
+      type: string
+    openfga-api-token:
+      description: |
+        API Token of the OpenFGA server.
+
+        For more information, refer to the Incus documentation:
+        https://linuxcontainers.org/incus/docs/main/server_config/#openfga-configuration
+      type: string
+    openfga-api-url:
+      description: |
+        URL of the OpenFGA server.
+
+        For more information, refer to the Incus documentation:
+        https://linuxcontainers.org/incus/docs/main/server_config/#openfga-configuration
+      type: string
+    openfga-store-id:
+      description: |
+        ID of the OpenFGA permission store.
+
+        For more information, refer to the Incus documentation:
+        https://linuxcontainers.org/incus/docs/main/server_config/#openfga-configuration
+      type: string
 
 actions:
   add-trusted-certificate:

--- a/src/incus.py
+++ b/src/incus.py
@@ -71,9 +71,13 @@ class IncusProcessError(Exception):
         return any(message in self.message for message in self.retryable_error_messages)
 
 
-def set_config(key: str, value: Union[str, int]):
-    """Set config `key` to `value` in the Incus daemon."""
-    run_command("config", "set", key, str(value))
+def set_config(configs: Dict[str, Optional[Union[str, int]]]):
+    """Set the given configs in the Incus daemon.
+
+    If any config value is `None`, the config will be unset in Incus.
+    """
+    keypairs = [f"{key}={value if value is not None else ''}" for key, value in configs.items()]
+    run_command("config", "set", *keypairs)
 
 
 def is_clustered() -> bool:


### PR DESCRIPTION
Adds config options related to OIDC and OpenFGA to the charm. This allows users to configure Incus to authenticate with external authentication and authorization providers without requiring any charm integrations.

Signed-off-by: Luís Simas <luissimas@protonmail.com>