### PR TITLE
feat: automatic ovn network creation

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -175,6 +175,40 @@ config:
         For more information, refer to the Incus documentation:
         https://linuxcontainers.org/incus/docs/main/server_config/#openfga-configuration
       type: string
+    ovn-uplink-network-type:
+      description: |
+        The type of network that will be used to create the OVN uplink network.
+
+        Valid values are: "physical" and "bridge".
+      default: bridge
+      type: string
+    ovn-uplink-network-config:
+      description: |
+        A space separated list of key value pairs in the form key=value to be set on the uplink
+        network that will be consumed by OVN networks.
+
+        The accepted values by Incus will vary based on the value of `ovn-uplink-network-type`. For
+        more information about supported values, refer to the Incus documentation:
+        https://linuxcontainers.org/incus/docs/main/reference/network_bridge
+        https://linuxcontainers.org/incus/docs/main/reference/network_physical
+      type: string
+    ovn-uplink-network-parent-interface:
+      description: |
+        The name of the network interface that should be used as the parent network for the OVN
+        uplink network. The interface name should be consistent across all units of the application.
+
+        This option only has effect if `ovn-uplink-network-type` is set to `physical`.
+      default: bridge
+      type: string
+    ovn-network-config:
+      description: |
+        A space separated list of key value pairs in the form key=value to be set on the OVN network.
+        Note that setting the `network` config option in this list has no effect, as the charm will
+        automatically set this option to match the created uplink network.
+
+        For more information about supported values, refer to the Incus documentation:
+        https://linuxcontainers.org/incus/docs/main/reference/network_ovn/
+      type: string
 
 actions:
   add-trusted-certificate:

--- a/src/charm.py
+++ b/src/charm.py
@@ -201,7 +201,7 @@ class IncusCharm(data_models.TypedCharmBase[IncusConfig]):
         )
         framework.observe(self.on.ceph_relation_created, self.on_ceph_relation_created)
         framework.observe(self.on.ceph_relation_changed, self.on_ceph_relation_changed)
-        framework.observe(self.on.ovsdb_cms_relation_created, self.on_ovsdb_cms_relation_created)
+        framework.observe(self.on.ovsdb_cms_relation_joined, self.on_ovsdb_cms_relation_joined)
         framework.observe(self.on.ovsdb_cms_relation_changed, self.on_ovsdb_cms_relation_changed)
 
         # Actions
@@ -768,8 +768,8 @@ class IncusCharm(data_models.TypedCharmBase[IncusConfig]):
         )
         logger.info("Ceph storage pool created.")
 
-    def on_ovsdb_cms_relation_created(self, event: ops.RelationCreatedEvent):
-        """Handle ovsdb-cms-relation-created event.
+    def on_ovsdb_cms_relation_joined(self, event: ops.RelationCreatedEvent):
+        """Handle ovsdb-cms-relation-joined event.
 
         Sets the unit's IP address on the relation data for ovn-central to
         create firewall rules allowing access to the ovn northbound database.

--- a/src/incus.py
+++ b/src/incus.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 CLIFormats = Literal["csv", "json", "table", "yaml", "compact"]
 IncusStorageDriver = Literal["dir", "btrfs", "zfs", "ceph"]
-IncusNetworkDriver = Literal["ovn"]
+IncusNetworkType = Literal["ovn", "physical", "bridge"]
 IncusClientCertificateType = Literal["client", "metrics"]
 
 INCUS_VAR_DIR = Path("/var/lib/incus")
@@ -236,6 +236,27 @@ def configure_storage(pool_name: str, pool_config: Dict[str, str]):
     args = ["storage", "set", pool_name]
     for name, value in pool_config.items():
         args.append(f"{name}={value}")
+    run_command(*args)
+
+
+def create_network(
+    network_name: str,
+    network_type: IncusNetworkType,
+    target: Optional[str] = None,
+    network_config: Optional[Dict[str, Optional[str]]] = None,
+):
+    """Create a network in Incus.
+
+    Driver-specific parameters can be specified in `network_config`.
+    """
+    args = ["network", "create", network_name, "--type", network_type]
+    if network_config:
+        for name, value in network_config.items():
+            if value is not None:
+                args.append(f"{name}={value}")
+    if target:
+        args.extend(["--target", target])
+
     run_command(*args)
 
 

--- a/tests/integration/bundles/incus_clustered.yaml.j2
+++ b/tests/integration/bundles/incus_clustered.yaml.j2
@@ -15,6 +15,9 @@ applications:
       "": alpha
     options:
       ceph-rbd-features: layering,deep-flatten
+      ovn-uplink-network-type: bridge
+      ovn-uplink-network-config: ipv4.address=10.179.176.1/24 ipv4.nat=true ipv4.dhcp=false ipv4.ovn.ranges=10.179.176.2-10.179.176.254
+      ovn-network-config: ipv4.nat=true
   vault:
     charm: vault
     channel: 1.8/stable

--- a/tests/unit/test_ceph_relation.py
+++ b/tests/unit/test_ceph_relation.py
@@ -258,7 +258,7 @@ def test_ceph_relation_changed_not_clustered_storage_pool_created():
         assert ctx.unit_status_history == [
             scenario.UnknownStatus(),
             scenario.MaintenanceStatus("Updating Ceph configuration files"),
-            scenario.MaintenanceStatus("Creating Ceph storage pool on Incus"),
+            scenario.MaintenanceStatus("Creating Ceph storage pool"),
         ]
         write_keyring_file.assert_called_once_with(ceph_user="any-app-name", key="any-ceph-key")
         write_ceph_conf_file.assert_called_once_with(
@@ -348,7 +348,7 @@ def test_ceph_relation_changed_leader_storage_pool_created():
         assert ctx.unit_status_history == [
             scenario.UnknownStatus(),
             scenario.MaintenanceStatus("Updating Ceph configuration files"),
-            scenario.MaintenanceStatus("Creating Ceph storage pool on Incus"),
+            scenario.MaintenanceStatus("Creating Ceph storage pool"),
         ]
         write_keyring_file.assert_called_once_with(ceph_user="any-app-name", key="any-ceph-key")
         write_ceph_conf_file.assert_called_once_with(

--- a/tests/unit/test_certificates_relation.py
+++ b/tests/unit/test_certificates_relation.py
@@ -595,7 +595,7 @@ def test_certificate_changed_ovn_not_created_leader():
             },
         )
 
-        ctx.run(ctx.on.relation_changed(relation=certificates_relation), state)
+        out = ctx.run(ctx.on.relation_changed(relation=certificates_relation), state)
 
         assert ctx.unit_status_history == [
             scenario.UnknownStatus(),
@@ -631,6 +631,7 @@ def test_certificate_changed_ovn_not_created_leader():
                 call(network_name="ovn", network_type="ovn", network_config={"network": "UPLINK"}),
             ]
         )
+        cluster_relation = out.get_relation(cluster_relation.id)
         assert cluster_relation.local_app_data.get("created-network") == '["ovn"]'
 
 

--- a/tests/unit/test_cluster_relation.py
+++ b/tests/unit/test_cluster_relation.py
@@ -392,7 +392,7 @@ def test_cluster_relation_changed_non_leader_not_clustered():
             },
         )
 
-        ctx.run(ctx.on.relation_changed(relation=relation, remote_unit=1), state)
+        out = ctx.run(ctx.on.relation_changed(relation=relation, remote_unit=1), state)
 
         bootstrap_node.assert_called_once()
         assert bootstrap_node.call_args.args[0]["cluster"] == {
@@ -406,6 +406,7 @@ def test_cluster_relation_changed_non_leader_not_clustered():
             scenario.UnknownStatus(),
             scenario.MaintenanceStatus("Bootstrapping Incus"),
         ]
+        relation = out.get_relation(relation.id)
         assert "joined-cluster-at" in relation.local_unit_data
 
 
@@ -459,7 +460,7 @@ def test_cluster_relation_changed_non_leader_not_clustered_failure_domain():
             },
         )
 
-        ctx.run(ctx.on.relation_changed(relation=relation, remote_unit=1), state)
+        out = ctx.run(ctx.on.relation_changed(relation=relation, remote_unit=1), state)
 
         bootstrap_node.assert_called_once()
         assert bootstrap_node.call_args.args[0]["cluster"] == {
@@ -476,6 +477,7 @@ def test_cluster_relation_changed_non_leader_not_clustered_failure_domain():
             scenario.UnknownStatus(),
             scenario.MaintenanceStatus("Bootstrapping Incus"),
         ]
+        relation = out.get_relation(relation.id)
         assert "joined-cluster-at" in relation.local_unit_data
 
 
@@ -528,7 +530,7 @@ def test_cluster_relation_changed_non_leader_not_clustered_failure_domain_disabl
             },
         )
 
-        ctx.run(ctx.on.relation_changed(relation=relation, remote_unit=1), state)
+        out = ctx.run(ctx.on.relation_changed(relation=relation, remote_unit=1), state)
 
         bootstrap_node.assert_called_once()
         assert bootstrap_node.call_args.args[0]["cluster"] == {
@@ -543,6 +545,7 @@ def test_cluster_relation_changed_non_leader_not_clustered_failure_domain_disabl
             scenario.UnknownStatus(),
             scenario.MaintenanceStatus("Bootstrapping Incus"),
         ]
+        relation = out.get_relation(relation.id)
         assert "joined-cluster-at" in relation.local_unit_data
 
 
@@ -825,7 +828,7 @@ def test_cluster_relation_changed_non_leader_ceph_pool_created():
             },
         )
 
-        ctx.run(ctx.on.relation_changed(relation=relation, remote_unit=1), state)
+        out = ctx.run(ctx.on.relation_changed(relation=relation, remote_unit=1), state)
 
         bootstrap_node.assert_called_once()
         assert bootstrap_node.call_args.args[0]["cluster"] == {
@@ -839,6 +842,7 @@ def test_cluster_relation_changed_non_leader_ceph_pool_created():
             scenario.UnknownStatus(),
             scenario.MaintenanceStatus("Bootstrapping Incus"),
         ]
+        relation = out.get_relation(relation.id)
         assert "joined-cluster-at" in relation.local_unit_data
 
 
@@ -943,7 +947,7 @@ def test_cluster_relation_changed_non_leader_ovn_ready():
             },
         )
 
-        ctx.run(ctx.on.relation_changed(relation=relation, remote_unit=1), state)
+        out = ctx.run(ctx.on.relation_changed(relation=relation, remote_unit=1), state)
 
         bootstrap_node.assert_called_once()
         assert bootstrap_node.call_args.args[0]["cluster"] == {
@@ -957,6 +961,7 @@ def test_cluster_relation_changed_non_leader_ovn_ready():
             scenario.UnknownStatus(),
             scenario.MaintenanceStatus("Bootstrapping Incus"),
         ]
+        relation = out.get_relation(relation.id)
         assert "joined-cluster-at" in relation.local_unit_data
 
 
@@ -1012,7 +1017,7 @@ def test_cluster_relation_changed_non_leader_ovn_network_created_uplink_physical
             },
         )
 
-        ctx.run(ctx.on.relation_changed(relation=relation, remote_unit=1), state)
+        out = ctx.run(ctx.on.relation_changed(relation=relation, remote_unit=1), state)
 
         bootstrap_node.assert_called_once()
         bootstrap_data = bootstrap_node.call_args.args[0]
@@ -1036,6 +1041,7 @@ def test_cluster_relation_changed_non_leader_ovn_network_created_uplink_physical
             scenario.UnknownStatus(),
             scenario.MaintenanceStatus("Bootstrapping Incus"),
         ]
+        relation = out.get_relation(relation.id)
         assert "joined-cluster-at" in relation.local_unit_data
 
 
@@ -1087,7 +1093,7 @@ def test_cluster_relation_changed_non_leader_ovn_network_created_uplink_bridge()
             },
         )
 
-        ctx.run(ctx.on.relation_changed(relation=relation, remote_unit=1), state)
+        out = ctx.run(ctx.on.relation_changed(relation=relation, remote_unit=1), state)
 
         bootstrap_node.assert_called_once()
         bootstrap_data = bootstrap_node.call_args.args[0]
@@ -1104,5 +1110,6 @@ def test_cluster_relation_changed_non_leader_ovn_network_created_uplink_bridge()
             scenario.UnknownStatus(),
             scenario.MaintenanceStatus("Bootstrapping Incus"),
         ]
+        relation = out.get_relation(relation.id)
         assert "joined-cluster-at" in relation.local_unit_data
         assert "ovn-uplink-interface" not in relation.local_unit_data

--- a/tests/unit/test_ovsdb_cms_relation.py
+++ b/tests/unit/test_ovsdb_cms_relation.py
@@ -40,11 +40,13 @@ def test_ovsdb_cms_relation_joined(address: str):
             leader=True, relations={ovsdb_cms_relation, cluster_relation}, networks={network}
         )
 
-        ctx.run(ctx.on.relation_joined(relation=ovsdb_cms_relation), state)
+        out = ctx.run(ctx.on.relation_joined(relation=ovsdb_cms_relation), state)
 
         assert ctx.unit_status_history == [
             scenario.UnknownStatus(),
         ]
+
+        ovsdb_cms_relation = out.get_relation(ovsdb_cms_relation.id)
         assert ovsdb_cms_relation.local_unit_data.get("cms-client-bound-address") == address
 
 
@@ -143,7 +145,7 @@ def test_ovsdb_cms_relation_changed_leader(addresses: List[str], expected_connec
             },
         )
 
-        ctx.run(ctx.on.relation_changed(relation=ovsdb_cms_relation), state)
+        out = ctx.run(ctx.on.relation_changed(relation=ovsdb_cms_relation), state)
 
         assert ctx.unit_status_history == [
             scenario.UnknownStatus(),
@@ -159,6 +161,7 @@ def test_ovsdb_cms_relation_changed_leader(addresses: List[str], expected_connec
             )
         )
 
+        cluster_relation = out.get_relation(cluster_relation.id)
         assert cluster_relation.local_app_data.get("ovn-nb-connection-ready") == "true"
         assert cluster_relation.local_app_data.get("created-network") == '["ovn"]'
 
@@ -336,7 +339,7 @@ def test_ovsdb_cms_relation_changed_leader_bridge_uplink():
             },
         )
 
-        ctx.run(ctx.on.relation_changed(relation=ovsdb_cms_relation), state)
+        out = ctx.run(ctx.on.relation_changed(relation=ovsdb_cms_relation), state)
 
         assert ctx.unit_status_history == [
             scenario.UnknownStatus(),
@@ -385,6 +388,7 @@ def test_ovsdb_cms_relation_changed_leader_bridge_uplink():
             ]
         )
 
+        cluster_relation = out.get_relation(cluster_relation.id)
         assert cluster_relation.local_app_data.get("ovn-nb-connection-ready") == "true"
         assert cluster_relation.local_app_data.get("created-network") == '["ovn"]'
 
@@ -458,7 +462,7 @@ def test_ovsdb_cms_relation_changed_leader_physical_uplink():
             },
         )
 
-        ctx.run(ctx.on.relation_changed(relation=ovsdb_cms_relation), state)
+        out = ctx.run(ctx.on.relation_changed(relation=ovsdb_cms_relation), state)
 
         assert ctx.unit_status_history == [
             scenario.UnknownStatus(),
@@ -507,5 +511,6 @@ def test_ovsdb_cms_relation_changed_leader_physical_uplink():
             ]
         )
 
+        cluster_relation = out.get_relation(cluster_relation.id)
         assert cluster_relation.local_app_data.get("ovn-nb-connection-ready") == "true"
         assert cluster_relation.local_app_data.get("created-network") == '["ovn"]'

--- a/tests/unit/test_ovsdb_cms_relation.py
+++ b/tests/unit/test_ovsdb_cms_relation.py
@@ -1,5 +1,5 @@
 from typing import List
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 import scenario
@@ -103,6 +103,7 @@ def test_ovsdb_cms_relation_changed_leader(addresses: List[str], expected_connec
         patch("charm.incus.is_clustered", return_value=True),
         patch("charm.incus.get_cluster_member_info"),
         patch("charm.incus.set_ovn_northbound_connection") as set_ovn_northbound_connection,
+        patch("charm.incus.create_network") as _create_network,
     ):
         ctx = scenario.Context(IncusCharm)
         ovsdb_cms_relation = scenario.Relation(
@@ -134,7 +135,12 @@ def test_ovsdb_cms_relation_changed_leader(addresses: List[str], expected_connec
             },
         )
         state = scenario.State(
-            leader=True, relations={ovsdb_cms_relation, certificates_relation, cluster_relation}
+            leader=True,
+            relations={ovsdb_cms_relation, certificates_relation, cluster_relation},
+            config={
+                "ovn-uplink-network-config": "any-key=any-value another-key=another-value",
+                "ovn-uplink-network-type": "bridge",
+            },
         )
 
         ctx.run(ctx.on.relation_changed(relation=ovsdb_cms_relation), state)
@@ -142,6 +148,7 @@ def test_ovsdb_cms_relation_changed_leader(addresses: List[str], expected_connec
         assert ctx.unit_status_history == [
             scenario.UnknownStatus(),
             scenario.MaintenanceStatus("Configuring OVN northbound connection"),
+            scenario.MaintenanceStatus("Creating OVN network"),
         ]
         set_ovn_northbound_connection.assert_called_once_with(
             incus.OvnConnectionOptions(
@@ -151,6 +158,8 @@ def test_ovsdb_cms_relation_changed_leader(addresses: List[str], expected_connec
                 northbound_connection=expected_connection,
             )
         )
+
+        assert cluster_relation.local_app_data.get("ovn-nb-connection-ready") == "true"
         assert cluster_relation.local_app_data.get("created-network") == '["ovn"]'
 
 
@@ -189,3 +198,314 @@ def test_ovsdb_cms_relation_changed_leader_no_addresses():
             scenario.UnknownStatus(),
         ]
         set_ovn_northbound_connection.assert_not_called()
+
+
+def test_ovsdb_cms_relation_changed_leader_network_created():
+    """Test the ovsdb-cms-relation-changed event on leader units when the OVN network is already created.
+
+    The unit should collect the ovn northbound database endpoints from the
+    relation data and set them in Incus. It should not try to create a new
+    OVN network.
+    """
+    with (
+        patch("charm.IncusCharm._package_installed", return_value=True),
+        patch("charm.incus.is_clustered", return_value=True),
+        patch("charm.incus.get_cluster_member_info"),
+        patch("charm.incus.set_ovn_northbound_connection") as set_ovn_northbound_connection,
+        patch("charm.incus.create_network") as create_network,
+    ):
+        ctx = scenario.Context(IncusCharm)
+        ovsdb_cms_relation = scenario.Relation(
+            endpoint="ovsdb-cms",
+            interface="ovsdb-cms",
+            remote_units_data={
+                i: {"bound-address": f'"{v}"'}
+                for i, v in enumerate(["10.10.10.1", "10.10.10.2", "10.10.11.3"])
+            },
+        )
+        certificates_relation = scenario.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+            remote_units_data={
+                0: {
+                    "ca": "any-ca",
+                    "client.cert": "any-client-cert",
+                    "client.key": "any-client-key",
+                    "incus_0.server.cert": "any-server-cert",
+                    "incus_0.server.key": "any-server-key",
+                },
+            },
+        )
+        cluster_relation = scenario.PeerRelation(
+            endpoint="cluster",
+            interface="incus-cluster",
+            local_app_data={
+                "tokens": "{}",
+                "cluster-certificate": "any-cluster-certificate",
+                "created-storage": "[]",
+                "created-network": '["ovn"]',
+                "ovn-nb-connection-ready": "true",
+            },
+        )
+        state = scenario.State(
+            leader=True, relations={ovsdb_cms_relation, certificates_relation, cluster_relation}
+        )
+
+        ctx.run(ctx.on.relation_changed(relation=ovsdb_cms_relation), state)
+
+        assert ctx.unit_status_history == [
+            scenario.UnknownStatus(),
+            scenario.MaintenanceStatus("Configuring OVN northbound connection"),
+        ]
+        set_ovn_northbound_connection.assert_called_once_with(
+            incus.OvnConnectionOptions(
+                client_cert="any-server-cert",
+                client_key="any-server-key",
+                client_ca="any-ca",
+                northbound_connection="ssl:10.10.10.1:6641,ssl:10.10.10.2:6641,ssl:10.10.11.3:6641",
+            )
+        )
+        create_network.assert_not_called()
+
+
+def test_ovsdb_cms_relation_changed_leader_bridge_uplink():
+    """Test the ovsdb-cms-relation-changed event on leader units when it triggers the creation of an OVN network with a bridge uplink.
+
+    The unit should collect the ovn northbound database endpoints from the
+    relation data, set them in Incus and create a new OVN network as well as
+    its uplink network.
+    """
+    with (
+        patch("charm.IncusCharm._package_installed", return_value=True),
+        patch("charm.incus.is_clustered", return_value=True),
+        patch("charm.incus.get_cluster_member_info"),
+        patch("charm.incus.set_ovn_northbound_connection") as set_ovn_northbound_connection,
+        patch("charm.incus.create_network") as create_network,
+    ):
+        ctx = scenario.Context(IncusCharm)
+        ovsdb_cms_relation = scenario.Relation(
+            endpoint="ovsdb-cms",
+            interface="ovsdb-cms",
+            remote_units_data={
+                i: {"bound-address": f'"{v}"'}
+                for i, v in enumerate(["10.10.10.1", "10.10.10.2", "10.10.11.3"])
+            },
+        )
+        certificates_relation = scenario.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+            remote_units_data={
+                0: {
+                    "ca": "any-ca",
+                    "client.cert": "any-client-cert",
+                    "client.key": "any-client-key",
+                    "incus_0.server.cert": "any-server-cert",
+                    "incus_0.server.key": "any-server-key",
+                },
+            },
+        )
+        cluster_relation = scenario.PeerRelation(
+            endpoint="cluster",
+            interface="incus-cluster",
+            local_app_data={
+                "tokens": "{}",
+                "cluster-certificate": "any-cluster-certificate",
+                "created-storage": "[]",
+                "created-network": "[]",
+            },
+            local_unit_data={
+                "node-name": "node-0",
+                "joined-cluster-at": "2024-12-03T12:28:53.206680+00:00",
+            },
+            peers_data={
+                1: {"node-name": "node-1"},
+                2: {
+                    "node-name": "node-2",
+                    "joined-cluster-at": "2024-12-03T12:28:58.206680+00:00",
+                },
+            },
+        )
+
+        state = scenario.State(
+            leader=True,
+            relations={ovsdb_cms_relation, certificates_relation, cluster_relation},
+            config={
+                "ovn-uplink-network-type": "bridge",
+                "ovn-uplink-network-config": "any-key=any-value another-key=another-value",
+                "ovn-network-config": "any-ovn-key=any-ovn-value another-ovn-key=another-ovn-value",
+            },
+        )
+
+        ctx.run(ctx.on.relation_changed(relation=ovsdb_cms_relation), state)
+
+        assert ctx.unit_status_history == [
+            scenario.UnknownStatus(),
+            scenario.MaintenanceStatus("Configuring OVN northbound connection"),
+            scenario.MaintenanceStatus("Creating OVN network"),
+        ]
+        set_ovn_northbound_connection.assert_called_once_with(
+            incus.OvnConnectionOptions(
+                client_cert="any-server-cert",
+                client_key="any-server-key",
+                client_ca="any-ca",
+                northbound_connection="ssl:10.10.10.1:6641,ssl:10.10.10.2:6641,ssl:10.10.11.3:6641",
+            )
+        )
+        create_network.assert_has_calls(
+            [
+                call(
+                    network_name="UPLINK",
+                    network_type="bridge",
+                    target="node-0",
+                    network_config={},
+                ),
+                call(
+                    network_name="UPLINK",
+                    network_type="bridge",
+                    target="node-2",
+                    network_config={},
+                ),
+                call(
+                    network_name="UPLINK",
+                    network_type="bridge",
+                    network_config={
+                        "any-key": "any-value",
+                        "another-key": "another-value",
+                    },
+                ),
+                call(
+                    network_name="ovn",
+                    network_type="ovn",
+                    network_config={
+                        "network": "UPLINK",
+                        "any-ovn-key": "any-ovn-value",
+                        "another-ovn-key": "another-ovn-value",
+                    },
+                ),
+            ]
+        )
+
+        assert cluster_relation.local_app_data.get("ovn-nb-connection-ready") == "true"
+        assert cluster_relation.local_app_data.get("created-network") == '["ovn"]'
+
+
+def test_ovsdb_cms_relation_changed_leader_physical_uplink():
+    """Test the ovsdb-cms-relation-changed event on leader units when it triggers the creation of an OVN network with a physical uplink.
+
+    The unit should collect the ovn northbound database endpoints from the
+    relation data, set them in Incus and create a new OVN network as well as
+    its uplink network.
+    """
+    with (
+        patch("charm.IncusCharm._package_installed", return_value=True),
+        patch("charm.incus.is_clustered", return_value=True),
+        patch("charm.incus.get_cluster_member_info"),
+        patch("charm.incus.set_ovn_northbound_connection") as set_ovn_northbound_connection,
+        patch("charm.incus.create_network") as create_network,
+    ):
+        ctx = scenario.Context(IncusCharm)
+        ovsdb_cms_relation = scenario.Relation(
+            endpoint="ovsdb-cms",
+            interface="ovsdb-cms",
+            remote_units_data={
+                i: {"bound-address": f'"{v}"'}
+                for i, v in enumerate(["10.10.10.1", "10.10.10.2", "10.10.11.3"])
+            },
+        )
+        certificates_relation = scenario.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+            remote_units_data={
+                0: {
+                    "ca": "any-ca",
+                    "client.cert": "any-client-cert",
+                    "client.key": "any-client-key",
+                    "incus_0.server.cert": "any-server-cert",
+                    "incus_0.server.key": "any-server-key",
+                },
+            },
+        )
+        cluster_relation = scenario.PeerRelation(
+            endpoint="cluster",
+            interface="incus-cluster",
+            local_app_data={
+                "tokens": "{}",
+                "cluster-certificate": "any-cluster-certificate",
+                "created-storage": "[]",
+                "created-network": "[]",
+            },
+            local_unit_data={
+                "node-name": "node-0",
+                "joined-cluster-at": "2024-12-03T12:28:53.206680+00:00",
+            },
+            peers_data={
+                1: {"node-name": "node-1"},
+                2: {
+                    "node-name": "node-2",
+                    "joined-cluster-at": "2024-12-03T12:28:58.206680+00:00",
+                    "ovn-uplink-interface": "eno2",
+                },
+            },
+        )
+        state = scenario.State(
+            leader=True,
+            relations={ovsdb_cms_relation, certificates_relation, cluster_relation},
+            config={
+                "ovn-uplink-network-type": "physical",
+                "ovn-uplink-network-config": "any-key=any-value another-key=another-value",
+                "ovn-network-config": "any-ovn-key=any-ovn-value another-ovn-key=another-ovn-value",
+                "ovn-uplink-network-parent-interface": "any-uplink-interface",
+            },
+        )
+
+        ctx.run(ctx.on.relation_changed(relation=ovsdb_cms_relation), state)
+
+        assert ctx.unit_status_history == [
+            scenario.UnknownStatus(),
+            scenario.MaintenanceStatus("Configuring OVN northbound connection"),
+            scenario.MaintenanceStatus("Creating OVN network"),
+        ]
+        set_ovn_northbound_connection.assert_called_once_with(
+            incus.OvnConnectionOptions(
+                client_cert="any-server-cert",
+                client_key="any-server-key",
+                client_ca="any-ca",
+                northbound_connection="ssl:10.10.10.1:6641,ssl:10.10.10.2:6641,ssl:10.10.11.3:6641",
+            )
+        )
+        create_network.assert_has_calls(
+            [
+                call(
+                    network_name="UPLINK",
+                    network_type="physical",
+                    target="node-0",
+                    network_config={"parent": "any-uplink-interface"},
+                ),
+                call(
+                    network_name="UPLINK",
+                    network_type="physical",
+                    target="node-2",
+                    network_config={"parent": "any-uplink-interface"},
+                ),
+                call(
+                    network_name="UPLINK",
+                    network_type="physical",
+                    network_config={
+                        "any-key": "any-value",
+                        "another-key": "another-value",
+                    },
+                ),
+                call(
+                    network_name="ovn",
+                    network_type="ovn",
+                    network_config={
+                        "network": "UPLINK",
+                        "any-ovn-key": "any-ovn-value",
+                        "another-ovn-key": "another-ovn-value",
+                    },
+                ),
+            ]
+        )
+
+        assert cluster_relation.local_app_data.get("ovn-nb-connection-ready") == "true"
+        assert cluster_relation.local_app_data.get("created-network") == '["ovn"]'

--- a/tests/unit/test_ovsdb_cms_relation.py
+++ b/tests/unit/test_ovsdb_cms_relation.py
@@ -9,8 +9,8 @@ from charm import IncusCharm
 
 
 @pytest.mark.parametrize("address", ["192.168.0.2", "10.0.2.84", "38.28.79.12"])
-def test_ovsdb_cms_relation_created(address: str):
-    """Test the ovsdb-cms-relation-created event.
+def test_ovsdb_cms_relation_joined(address: str):
+    """Test the ovsdb-cms-relation-joined event.
 
     The unit should put the IP address for the binding associated with the
     relation in the relation data.
@@ -40,7 +40,7 @@ def test_ovsdb_cms_relation_created(address: str):
             leader=True, relations={ovsdb_cms_relation, cluster_relation}, networks={network}
         )
 
-        ctx.run(ctx.on.relation_created(relation=ovsdb_cms_relation), state)
+        ctx.run(ctx.on.relation_joined(relation=ovsdb_cms_relation), state)
 
         assert ctx.unit_status_history == [
             scenario.UnknownStatus(),


### PR DESCRIPTION
Now the charm is able to automatically create an OVN network and its uplink on the Incus cluster.

This implementation accounts for three different cases of OVN network creation:

1. The ovsdb-cms relation is established after the Incus cluster is formed
2. The ovsdb-cms relation is established before the Incus cluster is formed
3. A new node is added into an existing Incus cluster in which a OVN network was already created by the charm

The first two cases are treated as a single case in the implementation. In such cases, the creation of the OVN network consists in first creating the uplink network on all cluster members, then instantiating this network in the cluster and finally creating the OVN network associating it with the uplink.

In the third case, the joining members include the uplink network in their bootstrap data to ensure that all cluster members have an uplink network setup.

Closes #6 