### PR TITLE
test: assert that failure domain is other than the default on all members

### DIFF
--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -296,7 +296,8 @@ async def test_add_unit(ops_test: OpsTest, tmp_path: Path):
         assert member["server_name"] in machine_hostnames
         assert member["status"] == "Online"
         assert member["message"] == "Fully operational"
-        assert member["failure_domain"] == "default"
+        # Since set-failure-domain is set to true, we expect some domain other than the default
+        assert member["failure_domain"] != "default"
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_charm_clustered.py
+++ b/tests/integration/test_charm_clustered.py
@@ -149,7 +149,8 @@ async def test_cluster_state(ops_test: OpsTest):
         assert member["server_name"] in machine_hostnames
         assert member["status"] == "Online"
         assert member["message"] == "Fully operational"
-        assert member["failure_domain"] == "default"
+        # Since set-failure-domain is set to true, we expect some domain other than the default
+        assert member["failure_domain"] != "default"
 
 
 @pytest.mark.abort_on_fail


### PR DESCRIPTION
When we first wrote these tests, the LXD cloud (which we use in our CI) did not support availability zones. For this reason, we asserted that all nodes had the "default" failure domain.

Juju 3.6.9 introduced support for availability zones in LXD clouds and sets them to the host name that is running the LXD VMs. With that in mind, we need to update the integration test to instead assert that we have a failure domain different than the default. Since our CI creates LXD nodes on-demand, it makes little sense to match an specific hostname.

References:
https://documentation.ubuntu.com/juju/3.6/reference/juju/juju-roadmap-and-releases/#lxd